### PR TITLE
fix: map missing theme tokens so HUD follows dark/light theme

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -29,6 +29,23 @@ window.__ModuleLoader__.load({
     const WIDTH_DEFAULT = 240;
 
     function apply(ctx) {
+      // 主题修复：把插件里使用的、DSH 主题不存在的变量名映射到真实 token，
+      // 让 HUD 面板跟随深色/浅色主题（否则全部回退硬编码浅色）。
+      if (!document.getElementById("dsh-hud-theme-fix")) {
+        const style = document.createElement("style");
+        style.id = "dsh-hud-theme-fix";
+        style.textContent = [
+          "body {",
+          "  --dsw-alias-bg-elevated: var(--dsw-alias-bg-overlay);",
+          "  --dsw-alias-text-primary: var(--dsw-alias-label-primary);",
+          "  --dsw-alias-text-secondary: var(--dsw-alias-label-secondary);",
+          "  --dsw-alias-text-tertiary: var(--dsw-alias-label-tertiary);",
+          "  --dsw-alias-border-strong: var(--dsw-alias-border-l2);",
+          "  --dsw-alias-border-weak: var(--dsw-alias-border-l1);",
+          "}",
+        ].join("\n");
+        document.head.appendChild(style);
+      }
       const slots = ctx.get("slots");
       if (slots === undefined) return;
       const timer = ctx.get("timer");


### PR DESCRIPTION
## Problem

The HUD panel uses CSS variables that do not exist in the DSH theme (`--dsw-alias-bg-elevated`, `--dsw-alias-text-primary/secondary/tertiary`, `--dsw-alias-border-strong/weak`). Every `var()` falls back to hardcoded light colors, so the panel renders with a white background even when DSH is in dark mode.

## Fix

Define the missing variable names as aliases on `body` (the same scope where the real DSH theme tokens are defined: `body` / `body[data-ds-dark-theme]`), mapping them to the actual tokens:

- `--dsw-alias-bg-elevated` → `--dsw-alias-bg-overlay`
- `--dsw-alias-text-primary/secondary/tertiary` → `--dsw-alias-label-primary/secondary/tertiary`
- `--dsw-alias-border-strong/weak` → `--dsw-alias-border-l2/l1`

The panel now follows the active DSH theme (dark or light).

Verified in DSH Desktop 2.0.0: HUD panel renders with dark background in dark mode.