### PR TITLE
fix: normalize CRLF/CR git output to stop empty-path HTTP 400

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -439,6 +439,7 @@ window.__ModuleLoader__.load({
           const git = snap.data && snap.data.git;
           const mcp = snap.data && Array.isArray(snap.data.mcp) ? snap.data.mcp : [];
           const skills = snap.data && Array.isArray(snap.data.skills) ? snap.data.skills : [];
+          const version = snap.data && typeof snap.data.version === "string" ? snap.data.version : null;
           const model = snap.data && snap.data.model;
           const modelName = model && model.model
             ? model.model.replace("deepseek-v4-", "") + (model.reasoningEffort ? " · " + model.reasoningEffort : "")
@@ -628,6 +629,13 @@ window.__ModuleLoader__.load({
             },
               react.createElement("span", { style: { display: "inline-flex", alignItems: "center", gap: "3px" } },
                 "⚙", modelName),
+              // DSH 宿主版本：host 从已加载的 @deepseek-ai/dsh package.json 读取（兼容 npx，不依赖 PATH 里的 dsh）
+              version !== null
+                ? react.createElement("span", {
+                    title: "DSH 版本",
+                    style: { display: "inline-flex", alignItems: "center", gap: "3px", color: "var(--dsw-alias-text-tertiary, #999)" },
+                  }, "v" + version.replace(/^v/, ""))
+                : null,
               // 官方余额（自动拉取；数据未到/失败/无凭据显示 --）
               // 注意：snap.data 未加载时 balance 是 undefined，必须用 != null 宽松判断
               react.createElement("span", {

--- a/lib/client.js
+++ b/lib/client.js
@@ -439,7 +439,6 @@ window.__ModuleLoader__.load({
           const git = snap.data && snap.data.git;
           const mcp = snap.data && Array.isArray(snap.data.mcp) ? snap.data.mcp : [];
           const skills = snap.data && Array.isArray(snap.data.skills) ? snap.data.skills : [];
-          const version = snap.data && typeof snap.data.version === "string" ? snap.data.version : null;
           const model = snap.data && snap.data.model;
           const modelName = model && model.model
             ? model.model.replace("deepseek-v4-", "") + (model.reasoningEffort ? " · " + model.reasoningEffort : "")
@@ -497,6 +496,7 @@ window.__ModuleLoader__.load({
           const refresh = () => fetchHud(current, false);
 
           const toggleDiff = (path) => {
+            if (typeof path !== "string" || path === "") return;
             const isOpen = expanded[path] === true;
             if (isOpen) {
               const next = { ...expanded };
@@ -515,6 +515,8 @@ window.__ModuleLoader__.load({
           };
 
           const renderFileRow = (file, clickable = true) => {
+            if (!file || typeof file.path !== "string" || file.path === "") return null;
+            const canOpenDiff = clickable && !file.untracked && file.path !== "";
             const summary = file.new
               ? react.createElement("span", { style: { color: "var(--dsw-alias-label-tertiary)", marginLeft: "auto", flexShrink: 0 } }, "new")
               : file.add + file.del > 0
@@ -527,11 +529,11 @@ window.__ModuleLoader__.load({
             const isOpen = expanded[file.path] === true;
             return react.createElement("div", { key: file.path },
               react.createElement("div", {
-                onClick: clickable ? () => toggleDiff(file.path) : undefined,
-                title: file.untracked ? "未跟踪文件" : (clickable ? "点击查看 diff" : ""),
+                onClick: canOpenDiff ? () => toggleDiff(file.path) : undefined,
+                title: file.untracked ? "未跟踪文件" : (canOpenDiff ? "点击查看 diff" : ""),
                 style: {
                   display: "flex", gap: "6px", fontSize: "12px", lineHeight: "21px",
-                  whiteSpace: "nowrap", cursor: clickable && !file.untracked ? "pointer" : "default",
+                  whiteSpace: "nowrap", cursor: canOpenDiff ? "pointer" : "default",
                 },
               },
                 react.createElement("span", { style: { color: statusColor(file.status), width: "20px", flexShrink: 0 } }, file.status),
@@ -626,13 +628,6 @@ window.__ModuleLoader__.load({
             },
               react.createElement("span", { style: { display: "inline-flex", alignItems: "center", gap: "3px" } },
                 "⚙", modelName),
-              // DSH 版本号（2026-08-20）：host 跑 `dsh --version` 返回，状态行常驻显示
-              version !== null
-                ? react.createElement("span", {
-                    title: "DSH 版本",
-                    style: { display: "inline-flex", alignItems: "center", gap: "3px", color: "var(--dsw-alias-text-tertiary, #999)" },
-                  }, "v" + version.replace(/^v/, ""))
-                : null,
               // 官方余额（自动拉取；数据未到/失败/无凭据显示 --）
               // 注意：snap.data 未加载时 balance 是 undefined，必须用 != null 宽松判断
               react.createElement("span", {

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,6 @@
  */
 import { existsSync, readdirSync, watch } from 'node:fs'
 import { basename, join } from 'node:path'
-import { homedir } from 'node:os'
 
 export const name = 'dsh-hud'
 // Dependencies must be declared via `inject` (ctx.get may return undefined for them)
@@ -154,7 +153,6 @@ export function apply(ctx) {
           const payload = light
             ? { count: cwd === null ? [] : await collectGitCount(shell, cwd, extraRepos) }
             : {
-                version: await collectVersion(shell),
                 git: await collectGit(shell, sessions, sessionId, extraRepos),
                 mcp: collectMcp(tools),
                 skills: await collectSkills(skills, agents, sessionId),
@@ -342,6 +340,7 @@ export const perModelUsageProjection = {
 const BALANCE_URL = 'https://api.deepseek.com/user/balance'
 const BALANCE_CACHE_MS = 60000
 let balanceCache = { at: 0, value: undefined } // value: undefined=未取过 null=失败/不可用
+
 async function collectBalance(credentials) {
   if (credentials === undefined) return null
   const now = Date.now()
@@ -373,29 +372,6 @@ async function collectBalance(credentials) {
   } catch (error) {
     console.warn('[dsh-hud] balance failed: ' + (error instanceof Error ? error.message : String(error)))
     balanceCache = { at: Date.now(), value: null }
-    return null
-  }
-}
-
-/** DSH 版本号（面板状态行显示，2026-08-20）：shell 跑 `dsh --version`，60s 缓存；失败返回 null。 */
-let versionCache = { at: 0, value: undefined } // value: undefined=未取过 null=失败/不可用
-async function collectVersion(shell) {
-  if (shell === undefined) return null
-  const now = Date.now()
-  if (versionCache.value !== undefined && now - versionCache.at < 60000) return versionCache.value
-  try {
-    const res = await shell.run(shell.resolve({
-      command: 'dsh --version',
-      workdir: homedir(),
-      timeoutMs: 5000,
-      stdoutMaxBytes: 4096,
-    }))
-    const text = res.stdout && res.stdout.text ? res.stdout.text.trim() : ''
-    versionCache = { at: now, value: text !== '' ? text : null }
-    return versionCache.value
-  } catch (error) {
-    console.warn('[dsh-hud] version failed: ' + (error instanceof Error ? error.message : String(error)))
-    versionCache = { at: now, value: null }
     return null
   }
 }
@@ -504,8 +480,7 @@ async function collectGitCount(shell, cwd, extraRepos) {
     const command = "for d in " + dirs.join(' ') + "; do [ -d \"$d/.git\" ] && { c=$(git -C \"$d\" status --porcelain 2>/dev/null | wc -l | tr -d ' '); echo \"$d:$c\"; }; done"
     const res = await runGit(shell, cwd, command, 65536)
     const out = []
-    for (const line of (res.text || '').split('\n')) {
-      if (line === '') continue
+    for (const line of normalizeLines(res.text || '')) {
       const i = line.lastIndexOf(':')
       if (i <= 0) continue
       const raw = line.slice(0, i)
@@ -551,6 +526,19 @@ async function collectGit(shell, sessions, sessionId, extraRepos) {
 }
 
 /**
+ * 统一拆分行：兼容 Unix LF、Windows CRLF、旧 Mac CR。
+ * 先归一化换行再丢空行，避免 CRLF 留下的裸 \r 被当成“空路径变更”。
+ */
+function normalizeLines(text) {
+  return String(text ?? '')
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n')
+    .split('\n')
+    .map((line) => line.replace(/\u0000/g, ''))
+    .filter((line) => line !== '')
+}
+
+/**
  * 解析 `git status --porcelain=v1 -b` 输出：
  * 首行 `## 分支... [ahead N, behind M]`；其余行 `XY 路径`（重命名带 `->`）。
  * 保留 X/Y 双列以支持暂存/未暂存分组，状态码归并为界面用单符号。
@@ -559,9 +547,7 @@ function parseStatus(branch, stdout) {
   let ahead = 0
   let behind = 0
   const files = []
-  for (const raw of stdout.split('\n')) {
-    if (raw === '') continue
-    const line = raw.replace(/\r/g, '') // 防 Windows CRLF 混入路径
+  for (const line of normalizeLines(stdout)) {
     if (line.startsWith('## ')) {
       const m = /ahead (\d+)/.exec(line)
       const n = /behind (\d+)/.exec(line)
@@ -571,11 +557,14 @@ function parseStatus(branch, stdout) {
       }
       continue
     }
+    // porcelain 至少是 `XY path`；短行/空路径视为脏输出，直接丢弃
+    if (line.length < 4) continue
     const index = line[0]
     const worktree = line[1]
-    let path = line.length > 3 ? line.slice(3) : ''
+    let path = line.slice(3)
     const arrow = path.indexOf(' -> ')
     if (arrow >= 0) path = path.slice(arrow + 4)
+    if (path === '') continue
     files.push({
       x: index,
       y: worktree,
@@ -602,9 +591,7 @@ function mergeStatus(index, worktree) {
 /** numstat 解析：`added\tdeleted\tpath`，兼容重命名（`old => new` / `{old => new}`）。 */
 function parseNumstat(text) {
   const map = new Map()
-  for (const raw of text.split('\n')) {
-    if (raw === '') continue
-    const line = raw.replace(/\r/g, '') // 防 Windows CRLF
+  for (const line of normalizeLines(text)) {
     const parts = line.split('\t')
     if (parts.length < 3) continue
     const add = parts[0] === '-' ? 0 : Number(parts[0])
@@ -616,6 +603,7 @@ function parseNumstat(text) {
       if (after.endsWith('}')) after = after.slice(0, -1)
       path = after
     }
+    if (path === '') continue
     map.set(path, { add, del })
   }
   return map
@@ -624,9 +612,7 @@ function parseNumstat(text) {
 /** `git log --pretty=format:%h|%s|%ct` 解析。 */
 function parseLog(text) {
   const out = []
-  for (const raw of text.split('\n')) {
-    if (raw === '') continue
-    const line = raw.replace(/\r/g, '') // 防 Windows CRLF
+  for (const line of normalizeLines(text)) {
     const i = line.indexOf('|')
     const j = line.indexOf('|', i + 1)
     if (i < 0 || j < 0) continue

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,7 @@
  * Only scalars/arrays are serialized — no live objects.
  */
 import { existsSync, readdirSync, watch } from 'node:fs'
+import { createRequire } from 'node:module'
 import { basename, join } from 'node:path'
 
 export const name = 'dsh-hud'
@@ -153,6 +154,7 @@ export function apply(ctx) {
           const payload = light
             ? { count: cwd === null ? [] : await collectGitCount(shell, cwd, extraRepos) }
             : {
+                version: collectVersion(),
                 git: await collectGit(shell, sessions, sessionId, extraRepos),
                 mcp: collectMcp(tools),
                 skills: await collectSkills(skills, agents, sessionId),
@@ -340,6 +342,35 @@ export const perModelUsageProjection = {
 const BALANCE_URL = 'https://api.deepseek.com/user/balance'
 const BALANCE_CACHE_MS = 60000
 let balanceCache = { at: 0, value: undefined } // value: undefined=未取过 null=失败/不可用
+
+/**
+ * 当前运行的 DSH 宿主版本（面板状态行显示）。
+ * 不跑 `dsh --version`：npx / 无全局 bin 时 PATH 里可能没有 dsh。
+ * 直接从已加载的 `@deepseek-ai/dsh` package.json 读取，失败再回退邻近包。
+ */
+let versionCache = undefined // undefined=未取过；string|null=已解析
+function collectVersion() {
+  if (versionCache !== undefined) return versionCache
+  const require = createRequire(import.meta.url)
+  const candidates = [
+    '@deepseek-ai/dsh/package.json',
+    '@deepseek-ai/dsh-web-app/package.json',
+    '@deepseek-ai/dsh-app-boot/package.json',
+  ]
+  for (const id of candidates) {
+    try {
+      const manifest = require(id)
+      if (manifest && typeof manifest.version === 'string' && manifest.version !== '') {
+        versionCache = manifest.version
+        return versionCache
+      }
+    } catch {
+      /* try next candidate */
+    }
+  }
+  versionCache = null
+  return null
+}
 
 async function collectBalance(credentials) {
   if (credentials === undefined) return null


### PR DESCRIPTION
## Problem
On Windows, git/shell output often uses CRLF. `parseStatus()` split on `\n` then stripped `\r`, but leftover empty lines (bare `\r`) were treated as changed files with `path: ""`. Clicking them requested `/api/dsh-hud/diff?...&path=` and got HTTP 400.

## Fix
- Add `normalizeLines()` for LF / CRLF / CR
- Use it in status/numstat/log/count parsers
- Skip invalid short lines and empty paths
- Client-side guard: don’t render/open diff for empty paths

## Test plan
- [ ] Clean repo on Windows: HUD shows no fake empty `M` file
- [ ] Dirty repo with CRLF output still lists real files
- [ ] Clicking a real file still loads diff
- [ ] Empty-path click no longer fires `/diff` 400